### PR TITLE
Added aliases to src folder (@) and node_modules folder (~).

### DIFF
--- a/src/configs/rollup.es5.config.js
+++ b/src/configs/rollup.es5.config.js
@@ -10,10 +10,14 @@ const alias = require('@rollup/plugin-alias')
 module.exports = {
   plugins: [
     alias({
-      'wpe-lightning': path.join(__dirname, '../alias/wpe-lightning.js'),
+      entries: {
+        'wpe-lightning': path.join(__dirname, '../alias/wpe-lightning.js'),
+        '@': path.resolve(process.cwd(), 'src/'),
+        '~': path.resolve(process.cwd(), 'node_modules/'),
+      },
     }),
     resolve({ mainFields: ['main', 'browser'] }),
-    commonjs(),
+    commonjs({ sourceMap: false }),
     babel({
       presets: [
         [

--- a/src/configs/rollup.es6.config.js
+++ b/src/configs/rollup.es6.config.js
@@ -8,6 +8,8 @@ module.exports = {
     alias({
       entries: {
         'wpe-lightning': path.join(__dirname, '../alias/wpe-lightning.js'),
+        '@': path.resolve(process.cwd(), 'src/'),
+        '~': path.resolve(process.cwd(), 'node_modules/'),
       },
     }),
     resolve({ mainFields: ['main', 'browser'] }),

--- a/src/helpers/build.js
+++ b/src/helpers/build.js
@@ -4,7 +4,6 @@ const execa = require('execa')
 const path = require('path')
 
 const spinner = require('../helpers/spinner')
-const exit = require('../helpers/exit')
 
 const removeFolder = folder => {
   spinner.start('Removing "' + folder.split('/').pop() + '" folder')


### PR DESCRIPTION
With this PR it becomes possible to import stuff easier in your App, by mapping `@` to the `src` folder and `~` to the `node_modules` folder.

The _src_ folder option (@) allows you to do this: `import Component from '@/src/components/Component1'` from any nested file inside your project (i.e. `src/pages/subpages/page123.js`). This eliminates the need for stuff like `import Component from '../../../Component1'`, which breaks when you move nested files around.

The _node_modules_ folder option (~) should be used only in cases where a package doesn't properly export files you want to import. For example `import moment from '~/moment/src/moment.js'`

The @ and ~ aliases are a common convention. Also used in VueJS for example.

